### PR TITLE
Upgrade Finitestate Python SDK pip package

### DIFF
--- a/Marketplace.md
+++ b/Marketplace.md
@@ -34,7 +34,7 @@ By default, the asset version will be assigned the existing values for Business 
 
 ## Set Up Workflow
 
-To start using this Extension, you must [install](https://learn.microsoft.com/en-us/azure/devops/marketplace/install-extension?view=azure-devops&tabs=browser) it using [Azure DevOps Markeplace](https://marketplace.visualstudio.com/items?itemName=christian-azr.binary-scan).
+To start using this Extension, you must [install](https://learn.microsoft.com/en-us/azure/devops/marketplace/install-extension?view=azure-devops&tabs=browser) it using [Azure DevOps Markeplace](https://marketplace.visualstudio.com/items?itemName=finite-state.binary-scan).
 
 After it is installed, you can use it in your pipeline by finding the task in the right Tasks panel:
 

--- a/Tasks/binaryScan/requirements.txt
+++ b/Tasks/binaryScan/requirements.txt
@@ -1,2 +1,2 @@
-finite-state-sdk==0.1.2
+finite-state-sdk==0.1.6
 azure-devops==7.1.0b4

--- a/Tasks/binaryScan/requirements.txt
+++ b/Tasks/binaryScan/requirements.txt
@@ -1,2 +1,2 @@
-finite-state-sdk==0.1.6
+finite-state-sdk==0.1.9
 azure-devops==7.1.0b4

--- a/Tasks/binaryScan/task.json
+++ b/Tasks/binaryScan/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "inputs": [
     {

--- a/Tasks/binaryScan/upload_binary.py
+++ b/Tasks/binaryScan/upload_binary.py
@@ -97,6 +97,7 @@ def create_and_upload_binary():
                     product_id=INPUT_PRODUCT_ID,
                     artifact_description=INPUT_ARTIFACT_DESCRIPTION,
                     quick_scan=INPUT_QUICK_SCAN == "true",
+                    upload_method=finite_state_sdk.UploadMethod.AZURE_DEVOPS_INTEGRATION,
                 )
                 asset_version = extract_asset_version(
                     response["launchBinaryUploadProcessing"]["key"]

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "binary-scan",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Finite State Binary Scan",
   "publisher": "finite-state",
   "public": true,


### PR DESCRIPTION
It upgrades python pip dependency from `0.1.2` to `0.1.9`.